### PR TITLE
feat: add node example get ip and latency

### DIFF
--- a/node-tool-get-ip-and-latency/.env.example
+++ b/node-tool-get-ip-and-latency/.env.example
@@ -1,0 +1,3 @@
+YOMO_SFN_NAME=my_first_llm_function_tool
+YOMO_SFN_ZIPPER="zipper.vivgrid.com:9000"
+YOMO_SFN_CREDENTIAL=<your-yomo-sfn-credential>

--- a/node-tool-get-ip-and-latency/README.md
+++ b/node-tool-get-ip-and-latency/README.md
@@ -1,0 +1,138 @@
+# LLM Function Calling - Get IP and Latency
+
+This is a serverless function for getting IP and Latency info.
+
+```sh
+YOMO_SFN_NAME=my_first_llm_function_tool
+YOMO_SFN_ZIPPER=zipper.vivgrid.com:9000
+YOMO_SFN_CREDENTIAL=<your-yomo-sfn-credential>
+```
+
+Other environment variables can be found in the [vivgrid dashboard](https://dashboard.vivgrid.com/) serverless page
+
+## Development
+
+### 1. Install YoMo CLI
+
+```bash
+curl -fsSL https://get.yomo.run | sh
+```
+
+Detail usages of the cli can be found on [Doc: YoMo CLI](https://yomo.run/docs/cli).
+
+### 2. Attach this function calling to your LLM Bridge
+
+```bash
+yomo run app.ts -n llm-tool-get-ip-and-latency
+```
+
+### 3. Trigger the function calling
+
+Test in your terminal:
+
+```bash
+curl https://api.vivgrid.com/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <token>" \
+  -d '{
+    "model": "gpt-4o",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Compare the website speed of Puma and Nike. Please provide a concise answer."
+      }
+    ]
+  }'
+```
+
+Based on the real time weather ifo, you may get response like:
+
+```json
+{
+  "id": "chatcmpl-B27HtaKk2XrWs5y9p7hf2jNBQLMiJ",
+  "object": "chat.completion",
+  "created": 1739844369,
+  "model": "gpt-4o-2024-08-06",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Puma's website (puma.com) has an IP address of 151.101.194.132 with an average latency of 252.080 ms. Meanwhile, Nike's website (nike.com) has an IP address of 108.157.254.92 with an average latency of 92.155 ms. Therefore, Nike's website is faster compared to Puma's website based on these latency measurements."
+      },
+      "finish_reason": "stop",
+      "content_filter_results": {
+        "hate": {
+          "filtered": false,
+          "severity": "safe"
+        },
+        "self_harm": {
+          "filtered": false,
+          "severity": "safe"
+        },
+        "sexual": {
+          "filtered": false,
+          "severity": "safe"
+        },
+        "violence": {
+          "filtered": false,
+          "severity": "safe"
+        },
+        "jailbreak": {
+          "filtered": false,
+          "detected": false
+        },
+        "profanity": {
+          "filtered": false,
+          "detected": false
+        }
+      }
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 247,
+    "completion_tokens": 139,
+    "total_tokens": 295,
+    "prompt_tokens_details": {
+      "audio_tokens": 0,
+      "cached_tokens": 0
+    },
+    "completion_tokens_details": {
+      "audio_tokens": 0,
+      "reasoning_tokens": 0
+    }
+  },
+  "system_fingerprint": "fp_f3927aa00d",
+  "prompt_filter_results": [
+    {
+      "index": 0,
+      "content_filter_results": {
+        "hate": {
+          "filtered": false,
+          "severity": "safe"
+        },
+        "self_harm": {
+          "filtered": false,
+          "severity": "safe"
+        },
+        "sexual": {
+          "filtered": false,
+          "severity": "safe"
+        },
+        "violence": {
+          "filtered": false,
+          "severity": "safe"
+        },
+        "jailbreak": {
+          "filtered": false,
+          "detected": false
+        },
+        "profanity": {
+          "filtered": false,
+          "detected": false
+        }
+      }
+    }
+  ]
+}
+```

--- a/node-tool-get-ip-and-latency/README.md
+++ b/node-tool-get-ip-and-latency/README.md
@@ -45,7 +45,7 @@ curl https://api.vivgrid.com/v1/chat/completions \
   }'
 ```
 
-Based on the real time weather ifo, you may get response like:
+You may get response like:
 
 ```json
 {

--- a/node-tool-get-ip-and-latency/app.ts
+++ b/node-tool-get-ip-and-latency/app.ts
@@ -1,0 +1,55 @@
+import * as dns from 'dns';
+import * as ping from 'ping';
+import { promisify } from 'util';
+
+// Description outlines the functionality for the LLM Function Calling feature
+export const description = `if user asks ip or network latency of a domain, you should return the result of the giving domain. try your best to dissect user expressions to infer the right domain names`;
+
+// Tag specifies the data tag that this serverless function subscribes to
+export const tag = 0x64;
+
+// Parameter defines the arguments for the LLM Function Calling
+export type Argument = {
+  domain: string;
+};
+
+const lookup = promisify(dns.lookup);
+
+async function getDomainInfo(domain: string): Promise<string> {
+  try {
+    // Get IP address
+    const { address: ip } = await lookup(domain);
+
+    // Get latency using ping
+    const pingResult = await ping.promise.probe(ip, {
+      timeout: 3,
+      extra: ['-c', '3'] // Send 3 packets
+    });
+
+    if (!pingResult.alive) {
+      return `domain ${domain} has ip ${ip}, but it does not support ICMP protocol or network is unavailable now, so I can not get the latency data`;
+    }
+
+    return `domain ${domain} has ip ${ip} with average latency ${pingResult.avg}ms, make sure answer with the IP address and Latency`;
+
+  } catch (error) {
+    console.error('Error:', error);
+    return 'can not get the domain name right now, please try again later';
+  }
+}
+
+/**
+ * Handler orchestrates the core processing logic of this function.
+ * @param args - LLM Function Calling Arguments.
+ * @returns The result of the retrieval is returned to the LLM for processing.
+ */
+export async function handler(args: Argument): Promise<string> {
+  if (!args.domain) {
+    console.warn('[sfn] domain is empty');
+    return 'can not get the domain name right now, please try again later';
+  }
+
+  const result = await getDomainInfo(args.domain);
+  console.log('[sfn] result:', result);
+  return result;
+}

--- a/node-tool-get-ip-and-latency/package.json
+++ b/node-tool-get-ip-and-latency/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "tool-node-get-ip-and-latency",
+  "version": "1.0.0",
+  "description": "LLM Function Calling - Get IP and Latency",
+  "main": ".wrapper.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@types/node": "^22.10.1",
+    "@types/ping": "^0.4.4",
+    "typescript": "^5.7.2"
+  },
+  "dependencies": {
+    "@yomo/sfn": "^1.0.5",
+    "ping": "^0.4.4"
+  }
+}

--- a/node-tool-get-ip-and-latency/tsconfig.json
+++ b/node-tool-get-ip-and-latency/tsconfig.json
@@ -1,0 +1,111 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+
+    /* Projects */
+    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+
+    /* Modules */
+    "module": "commonjs",                                /* Specify what module code is generated. */
+    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
+    // "rewriteRelativeImportExtensions": true,          /* Rewrite '.ts', '.tsx', '.mts', and '.cts' file extensions in relative import paths to their JavaScript equivalent in output files. */
+    // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
+    // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
+    // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
+    // "noUncheckedSideEffectImports": true,             /* Check side effect imports. */
+    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
+    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+
+    /* Emit */
+    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+    // "isolatedDeclarations": true,                     /* Require sufficient annotation on exports so other tools can trivially generate declaration files. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+
+    /* Type Checking */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "strictBuiltinIteratorReturn": true,              /* Built-in iterators are instantiated with a 'TReturn' type of 'undefined' instead of 'any'. */
+    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+  }
+,"include":[".wrapper.ts"]}


### PR DESCRIPTION
This pull request introduces a new serverless function for obtaining IP and latency information. The changes include adding environment variables, updating documentation, implementing the core functionality, and setting up the project configuration.

Key changes:

### Environment Setup:
* Added new environment variables to the `.env.example` file for configuring the serverless function (`YOMO_SFN_NAME`, `YOMO_SFN_ZIPPER`, `YOMO_SFN_CREDENTIAL`).

### Documentation:
* Updated the `README.md` file to include instructions for setting up and using the serverless function, including installation of YoMo CLI and example usage.

### Core Functionality:
* Implemented the main logic in `app.ts` to retrieve IP and latency information using `dns` and `ping` modules. This includes defining the function description, tag, argument type, and handler.

### Project Configuration:
* Added `package.json` to manage project dependencies and scripts, including `@yomo/sfn` and `ping` modules.
* Added `tsconfig.json` to configure TypeScript compiler options for the project.